### PR TITLE
Fix broken ${TOUCH_COMMAND} ${_sip_output_files} on Windows.

### DIFF
--- a/python_orocos_kdl/cmake/SIPMacros.cmake
+++ b/python_orocos_kdl/cmake/SIPMacros.cmake
@@ -37,7 +37,7 @@
 
 SET(SIP_INCLUDES)
 SET(SIP_TAGS)
-SET(SIP_CONCAT_PARTS 1)
+SET(SIP_CONCAT_PARTS 8)
 SET(SIP_DISABLE_FEATURES)
 SET(SIP_EXTRA_OPTIONS)
 
@@ -92,20 +92,10 @@ MACRO(ADD_SIP_PYTHON_MODULE MODULE_NAME MODULE_SIP)
         ENDIF( ${CONCAT_NUM} LESS ${SIP_CONCAT_PARTS} )
     ENDFOREACH(CONCAT_NUM RANGE 0 ${SIP_CONCAT_PARTS} )
 
-    IF(NOT WIN32)
-        SET(TOUCH_COMMAND touch)
-    ELSE(NOT WIN32)
-        SET(TOUCH_COMMAND echo)
-        # instead of a touch command, give out the name and append to the files
-        # this is basically what the touch command does.
-        FOREACH(filename ${_sip_output_files})
-            FILE(APPEND filename "")
-        ENDFOREACH(filename ${_sip_output_files})
-    ENDIF(NOT WIN32)
     ADD_CUSTOM_COMMAND(
         OUTPUT ${_sip_output_files} 
         COMMAND ${CMAKE_COMMAND} -E echo ${message}
-        COMMAND ${TOUCH_COMMAND} ${_sip_output_files} 
+        COMMAND ${CMAKE_COMMAND} -E touch ${_sip_output_files}
         COMMAND ${SIP_EXECUTABLE} ${_sip_tags} ${_sip_x} ${SIP_EXTRA_OPTIONS} -j ${SIP_CONCAT_PARTS} -c ${CMAKE_CURRENT_SIP_OUTPUT_DIR} ${_sip_includes} ${_abs_module_sip}
         DEPENDS ${_abs_module_sip} ${SIP_EXTRA_FILES_DEPEND}
     )


### PR DESCRIPTION
SIP takes .sip to generate C++ code to build native Python binding module, and SIP_CONCAT_PARTS decides how many C++ files to generate for parallel build. And since we don't know how many parts SIP are actually created in Cmake configuration time, it emits command to generate the stub Cpp files in case they are not there, and the problem is the "touch" implementation is broken on Windows (which is generating a file called "filename" under the current directory).

Instead of special handling the touch commands for Windows, replace the logic with a more generic "COMMAND ${CMAKE_COMMAND} -E touch ${_sip_output_files}" to be cross platform.